### PR TITLE
fixed issue with multiple API calls in pages

### DIFF
--- a/src/pages/Agents.jsx
+++ b/src/pages/Agents.jsx
@@ -10,7 +10,7 @@ const Agents = () => {
 
   useEffect(()=> {
     fetchAgents(lang);
-  }, [fetchAgents,lang])
+  }, [lang])
 
   return (
     <div>

--- a/src/pages/Gears.jsx
+++ b/src/pages/Gears.jsx
@@ -10,7 +10,7 @@ const Gears = () => {
 
   useEffect(()=> {
     fetchGears(lang);
-  }, [fetchGears,lang])
+  }, [lang])
 
   return (
     <div>

--- a/src/pages/Maps.jsx
+++ b/src/pages/Maps.jsx
@@ -10,7 +10,7 @@ const Maps = () => {
 
   useEffect(()=> {
     fetchMaps(lang);
-  }, [fetchMaps,lang])
+  }, [lang])
 
   return (
     <div>

--- a/src/pages/Weapons.jsx
+++ b/src/pages/Weapons.jsx
@@ -10,7 +10,7 @@ const Weapons = () => {
   
   useEffect(()=> {
     fetchWeapons(lang);
-  }, [fetchWeapons,lang])
+  }, [lang])
 
   return (
     <div>


### PR DESCRIPTION
Up until now, accessing each page would call the API an infinite number of times. This was due to the `useEffect` containing the function from the context in the dependency array. This is shown [here](https://youtu.be/5KINwwr3Vuk)

This PR solves that issue.